### PR TITLE
Comment handling, NoCallTo handling, != handling, circular dependency in predicatetree

### DIFF
--- a/src/main/java/de/upb/docgen/ConstraintCrySLVC.java
+++ b/src/main/java/de/upb/docgen/ConstraintCrySLVC.java
@@ -327,6 +327,7 @@ public class ConstraintCrySLVC {
 								}
 							}
 						}
+						if (RHSStr.contains("noCallTo")) break; // mode() => noCallTo is not correctly handled temp fix to ensure doc generation
 						resRHSList.add(joinedRHS);
 
 						String varrhsone = resRHSList.get(1);

--- a/src/main/java/de/upb/docgen/ConstraintsComparison.java
+++ b/src/main/java/de/upb/docgen/ConstraintsComparison.java
@@ -601,9 +601,13 @@ public class ConstraintsComparison {
 							int indexOp = splitCompListTwo.indexOf("<");
 							subListLHS = splitCompListTwo.subList(0, indexOp);
 							subListRHS = splitCompListTwo.subList(indexOp, splitCompListTwo.size());
-						} else {
+						} else if (splitCompListTwo.contains(">=")) {
 
 							int indexOp = splitCompListTwo.indexOf(">=");
+							subListLHS = splitCompListTwo.subList(0, indexOp);
+							subListRHS = splitCompListTwo.subList(indexOp, splitCompListTwo.size());
+						} else {
+							int indexOp = splitCompListTwo.indexOf("!=");
 							subListLHS = splitCompListTwo.subList(0, indexOp);
 							subListRHS = splitCompListTwo.subList(indexOp, splitCompListTwo.size());
 						}

--- a/src/main/java/de/upb/docgen/Order.java
+++ b/src/main/java/de/upb/docgen/Order.java
@@ -123,6 +123,7 @@ public class Order {
 		Map<String, List<String>> labelIdentifiersmap = new LinkedHashMap<>();
 
 		for (String line : lines) {
+			if (line.contains("//")) continue;
 			if (!line.contains(":")) {
 				throw new RuntimeException("Unexpected line found: " + line);
 			}
@@ -169,7 +170,9 @@ public class Order {
 			}
 		}
 
-		labelIdentifiersmap.forEach((key, idList) -> {
+		for (Map.Entry<String, List<String>> entry : labelIdentifiersmap.entrySet()) {
+			String key = entry.getKey();
+			List<String> idList = entry.getValue();
 			Event event = new Event(key);
 			for (String id : idList) {
 				String method = methodIdentifiersmap.get(id);
@@ -251,7 +254,7 @@ public class Order {
 			}
 			eventList.add(event);
 
-		});
+		}
 
 		{
 			methodIdentifiersmap.forEach((key, methodList) -> {
@@ -522,12 +525,12 @@ public class Order {
 					i -=2;
 				} else if (n.get(i).startsWith(symbolMap.get(")"))) {
 					//removing closing brackets and lowering the level
-					while (n.get(i).startsWith(symbolMap.get(")"))) {
+					while (n.size() > i && n.get(i).startsWith(symbolMap.get(")"))) {
 						identlevel--;
 						n.remove(i);
 					}
 					//remove already processed sentences
-					if (!n.get(i).startsWith(symbolMap.get("|"))) {
+					if (n.size() > i && !n.get(i).startsWith(symbolMap.get("|"))) {
 						n.remove(i);
 					}
 					i -= 2;


### PR DESCRIPTION
Added simple handling of comment detection to prevent the doc generation from failing. 

While investgating the issue. Some other issues were found. 
After mode() => NoCallTo the nocallto is not properly resolved. The issue is unclear but is temporarely fixed by ignoring the case.
!= in a comparsion constraint was not considered before is handled now.
Improved the circular dependecy detection in the PredicateTreeGeneration.
